### PR TITLE
fix: fix cannot download on production server

### DIFF
--- a/src/components/MoreOperation.vue
+++ b/src/components/MoreOperation.vue
@@ -49,10 +49,16 @@ export default {
   emits: ['updated'],
   methods: {
     downloadObject(objectKey) {
-      Storage.get(objectKey, { download: true }).then((result) => {
+      Storage.get(objectKey, { download: true }).then(async (result) => {
         // ダウンロード処理
         if (result.Body) {
-          const blob = result.Body
+          console.debug("result:", result)
+          const typeOfBody = Object.prototype.toString.call(result.Body)
+          console.debug("type:", typeOfBody)
+          // XXX: デプロイするとなぜか ReadableStream になる……
+          const isReadableStream = typeOfBody == "[object ReadableStream]";
+          const blob = isReadableStream ? await new Response(result.Body).blob() : result.Body
+
           const url = URL.createObjectURL(blob)
           const a = document.createElement('a')
           a.href = url


### PR DESCRIPTION
`result.Body`がデプロイ(ビルド？)すると`ReadableStream`となっていたため、 ローカルでも動くように暫定的に対処。

Close #17